### PR TITLE
install on other debian: wget ...: http -> https

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Other Debian based Linux
 sendto_silhouette.py to ~/.config/inkscape/extensions/ or (if you have permissions)  /usr/share/inkscape/extensions/
 
 * sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/jnweiger:/fablab/xUbuntu_14.04/ /' >> /etc/apt/sources.list.d/python-usb.list"
-* wget http://download.opensuse.org/repositories/home:jnweiger:fablab/xUbuntu_14.10/Release.key -O - | sudo apt-key add -
+* wget https://download.opensuse.org/repositories/home:jnweiger:fablab/xUbuntu_14.10/Release.key -O - | sudo apt-key add -
 * sudo apt-get update
 * sudo apt-get install python-usb
 * restart inkscape, check the menu entry Extensions -> Export -> Send to Silhouette


### PR DESCRIPTION
fix for #47

wget 404'd trying to get the key from: http://download.opensuse.org/repositories/home:jnweiger:fablab/xUbuntu_14.10/Release.key
but succeeds with:  https://download.opensuse.org/repositories/home:jnweiger:fablab/xUbuntu_14.10/Release.key